### PR TITLE
Enable license tests on `push`

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -1,7 +1,6 @@
 name: Run License Tests
 on:
-  # TODO: re-enable after troubleshooting dependencies (https://github.com/NeonGeckoCom/neon-stt-plugin-nemo/actions/runs/4418988018/jobs/7746831407)
-#  push:
+  push:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description
<!-- Provide a brief description of this PR -->

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
It appears the automation was copy-pasted from a different repo where tests were disabled